### PR TITLE
Changed round bracket to square bracket in Serilog dependency (nuspec)

### DIFF
--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -37,12 +37,13 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ServiceBus, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\WindowsAzure.ServiceBus.2.5.3.0\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
+    <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.ServiceBus.3.4.0\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Configuration">
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.3.0\lib\net45\Serilog.dll</HintPath>

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -45,11 +45,11 @@
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.2.3.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.Sinks.PeriodicBatching.2.0.0\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.Sinks.PeriodicBatching.2.0.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
@@ -11,8 +11,10 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging azure</tags>
     <dependencies>
-      <dependency id="Serilog" version="[1.4.204,2]" />
-      <dependency id="WindowsAzure.ServiceBus" version="2.5.3.0" />
+      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
+      <dependency id="Serilog" version="[2,2.3.0]" />
+      <dependency id="Serilog.Sinks.PeriodicBatching" version="[2,2.0.1]" />
+      <dependency id="WindowsAzure.ServiceBus" version="3.4.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging azure</tags>
     <dependencies>
-      <dependency id="Serilog" version="[1.4.204,2)" />
+      <dependency id="Serilog" version="[1.4.204,2]" />
       <dependency id="WindowsAzure.ServiceBus" version="2.5.3.0" />
     </dependencies>
   </metadata>

--- a/src/Serilog.Sinks.AzureEventHub/app.config
+++ b/src/Serilog.Sinks.AzureEventHub/app.config
@@ -1,5 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
+  </appSettings>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider"
+          type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+          serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider"
+          type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+          serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
   <system.serviceModel>
     <extensions>
       <!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->
@@ -26,20 +45,4 @@
       </bindingExtensions>
     </extensions>
   </system.serviceModel>
-  <appSettings>
-    <!-- Service Bus specific app setings for messaging connections -->
-    <add key="ClientSettingsProvider.ServiceUri" value="" />
-  </appSettings>
-  <system.web>
-    <membership defaultProvider="ClientAuthenticationMembershipProvider">
-      <providers>
-        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
-      </providers>
-    </membership>
-    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
-      <providers>
-        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
-      </providers>
-    </roleManager>
-  </system.web>
 </configuration>

--- a/src/Serilog.Sinks.AzureEventHub/packages.config
+++ b/src/Serilog.Sinks.AzureEventHub/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net45" />
   <package id="Serilog" version="2.3.0" targetFramework="net45" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.0.1" targetFramework="net45" />
-  <package id="WindowsAzure.ServiceBus" version="2.5.3.0" targetFramework="net45" />
+  <package id="WindowsAzure.ServiceBus" version="3.4.0" targetFramework="net45" />
 </packages>

--- a/src/Serilog.Sinks.AzureEventHub/packages.config
+++ b/src/Serilog.Sinks.AzureEventHub/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
-  <package id="Serilog" version="2.0.0" targetFramework="net45" />
-  <package id="Serilog.Sinks.PeriodicBatching" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog" version="2.3.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.0.1" targetFramework="net45" />
   <package id="WindowsAzure.ServiceBus" version="2.5.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
In the current version of the Serilog.Sinks.AzureEventHub.nuspec file it is not possible to install the NuGet package. Dependency in the nuspec file requires Serilog version greater than or equal to 1.4.204 and lower than 2.0.0, but at the same time Serilog.Sinks.PeriodicBatching depends on Serilog greater than or equal to 2.0.0. Moreover, last commit updated Serilog to 2.0.0.

![serilog sinks azureeventhub_dependency](https://cloud.githubusercontent.com/assets/3171329/19088558/fd968d18-8a76-11e6-8f02-5d1cc6751385.JPG)
