### PR TITLE
Add net461 as a target framework.

### DIFF
--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -4,7 +4,7 @@
 		<Description>Write Serilog events to Azure Event Hub</Description>
 		<VersionPrefix>4.0.1</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<AssemblyName>Serilog.Sinks.AzureEventHub</AssemblyName>
 		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
We're running into a problem where loading this assembly throws an exception on Windows Server:

Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.

Adding net461 fixed it.

I went with 461 because it's the lowest version that all the Nuget dependencies support.