### PR TITLE
Add log event properties to eventhubdata

### DIFF
--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubBatchingSink.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubBatchingSink.cs
@@ -80,6 +80,10 @@ namespace Serilog.Sinks.AzureEventHub
                 
                 eventHubData.Properties.Add("Type", "SerilogEvent");
                 eventHubData.Properties.Add("Level", logEvent.Level.ToString());
+                foreach (var logEventProperty in logEvent.Properties)
+                {
+                    eventHubData.Properties.Add(logEventProperty.Key, logEventProperty.Value.ToString());
+                }
 
                 batchedEvents.Add(eventHubData);
             }

--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubSink.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubSink.cs
@@ -58,6 +58,10 @@ namespace Serilog.Sinks.AzureEventHub
             var eventHubData = new EventData(body);
             eventHubData.Properties.Add("Type", "SerilogEvent");
             eventHubData.Properties.Add("Level", logEvent.Level.ToString());
+            foreach (var logEventProperty in logEvent.Properties)
+            {
+                eventHubData.Properties.Add(logEventProperty.Key, logEventProperty.Value.ToString());
+            }
 
             //Unfortunately no support for async in Serilog yet
             //https://github.com/serilog/serilog/issues/134


### PR DESCRIPTION
EventHub Data will always ignore `LogEvent` Properties, this PR will pass and allow EventHubData to use them.
LogEvent properties can contain a lot of additional information from the program and it will be usually used with Sentry or other Serilog Sinks.