### PR TITLE
Remove ServiceBus reference which causes NU1605

### DIFF
--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -25,7 +25,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
-		<PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
 		<PackageReference Include="Serilog" Version="2.5.0" />
 		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
 	</ItemGroup>


### PR DESCRIPTION
Microsoft.Azure.ServiceBus reference doesn't seem to be needed and causes following error

```
error NU1605:  Serilog.Sinks.AzureEventHub 4.1.0 -> Microsoft.Azure.ServiceBus 2.0.0 -> Microsoft.Azure.Amqp 2.1.2 -> System.Net.WebSockets.Client 4.0.0 -> System.Net.Primitives 4.0.11 -> runtime.win.System.Net.Primitives 4.3.0 -> Microsoft.Win32.Primitives (>= 4.3.0)
```