### PR TITLE
Add .NET 4.5.1 target and fix nuspec

### DIFF
--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Description>Write Serilog events to Azure Event Hub</Description>
-		<VersionPrefix>4.1.0</VersionPrefix>
+		<VersionPrefix>5.0.0</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
 		<TargetFrameworks>netstandard2.0;net461;net451</TargetFrameworks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -3,7 +3,7 @@
 		<Description>Write Serilog events to Azure Event Hub</Description>
 		<VersionPrefix>4.1.0</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
-		<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net461;net451</TargetFrameworks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<AssemblyName>Serilog.Sinks.AzureEventHub</AssemblyName>
 		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
@@ -12,10 +12,9 @@
     <repository type="git" url="https://github.com/serilog/serilog-sinks-azureeventhub" />
     <tags>serilog logging azure</tags>
     <dependencies>
-      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
-      <dependency id="Serilog" version="[2,2.3.0]" />
-      <dependency id="Serilog.Sinks.PeriodicBatching" version="[2,2.0.1]" />
-      <dependency id="WindowsAzure.ServiceBus" version="3.4.0" />
+      <dependency id="Serilog" version="[2.2.0,2.5.0]" />
+      <dependency id="Serilog.Sinks.PeriodicBatching" version="[2,2.1.1]" />
+      <dependency id="Microsoft.Azure.EventHubs" version="[1.0.3]" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
- Add .NET 4.5.1 target (min allowed by current dependencies)
- Remove stale dependencies (_WindowsAzure.ServiceBus_ and _Microsoft.WindowsAzure.ConfigurationManager_) from nuspec
- Update max versions of _Serilog_ and _Serilog.Sinks.PeriodicBatching_ in nuspec to match versions in csproj
- Add _Microsoft.Azure.EventHubs_ (version from csproj) in nuspec