### PR TITLE
Update Microsoft.Azure.EventHubs 1.0.3 to 4.3.1

### DIFF
--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -19,8 +19,6 @@
 		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
 		<RootNamespace>Serilog</RootNamespace>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<!-- Don't reference the full NETStandard.Library -->
-		<DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Azure.EventHubs" Version="4.*" />

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -24,7 +24,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
+		<PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.1" />
 		<PackageReference Include="Serilog" Version="2.5.0" />
 		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
 	</ItemGroup>

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Description>Write Serilog events to Azure Event Hub</Description>
-		<VersionPrefix>5.0.1</VersionPrefix>
+		<VersionPrefix>6.0.0</VersionPrefix>
 		<Authors>Serilog Contributors</Authors>
-		<TargetFrameworks>netstandard2.0;net461;net451</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<AssemblyName>Serilog.Sinks.AzureEventHub</AssemblyName>
 		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
 		<SignAssembly>true</SignAssembly>
 		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 		<PackageId>Serilog.Sinks.AzureEventHub</PackageId>
-		<PackageTags>serilog;;azure;eventhub</PackageTags>
+		<PackageTags>serilog;azure;eventhub</PackageTags>
 		<PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
 		<PackageProjectUrl>http://serilog.net</PackageProjectUrl>
 		<PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
@@ -22,9 +22,8 @@
 		<!-- Don't reference the full NETStandard.Library -->
 		<DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
 	</PropertyGroup>
-
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.1" />
+		<PackageReference Include="Microsoft.Azure.EventHubs" Version="4.*" />
 		<PackageReference Include="Serilog" Version="2.5.0" />
 		<PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
 	</ItemGroup>

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -11,15 +11,15 @@
 		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 		<PackageId>Serilog.Sinks.AzureEventHub</PackageId>
 		<PackageTags>serilog;azure;eventhub</PackageTags>
-		<PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
 		<PackageProjectUrl>http://serilog.net</PackageProjectUrl>
-		<PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<RepositoryUrl>https://github.com/serilog/serilog-sinks-azureeventhub</RepositoryUrl>
     	        <RepositoryType>git</RepositoryType>
 		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
 		<RootNamespace>Serilog</RootNamespace>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Azure.EventHubs" Version="4.*" />
 		<PackageReference Include="Serilog" Version="2.5.0" />

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
@@ -14,7 +14,7 @@
     <dependencies>
       <dependency id="Serilog" version="[2.2.0,2.5.0]" />
       <dependency id="Serilog.Sinks.PeriodicBatching" version="[2,2.1.1]" />
-      <dependency id="Microsoft.Azure.EventHubs" version="[1.0.3]" />
+      <dependency id="Microsoft.Azure.EventHubs" version="4.*" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.nuspec
@@ -7,8 +7,8 @@
     <description>Serilog event sink that writes to Azure Event Hubs.</description>
     <language>en-US</language>
     <projectUrl>http://serilog.net</projectUrl>
-    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
-    <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <repository type="git" url="https://github.com/serilog/serilog-sinks-azureeventhub" />
     <tags>serilog logging azure</tags>
     <dependencies>


### PR DESCRIPTION
Updates the main dependency to the latest version of the event hub SDK. 
Without this change the sink will not work on .net5 as the sink throws a silent exception.
v1 of the event hub SDK is 4 years old so probably lots of other improvements, including better support AMQP