### PR TITLE
feat!: Support properties to be included in event data

### DIFF
--- a/src/Serilog.Sinks.AzureEventHub/AuditLoggerConfigurationAzureEventHubExtensions.cs
+++ b/src/Serilog.Sinks.AzureEventHub/AuditLoggerConfigurationAzureEventHubExtensions.cs
@@ -51,16 +51,16 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum
             )
         {
-            if (loggerConfiguration == null) 
+            if (loggerConfiguration == null)
                 throw new ArgumentNullException("loggerConfiguration");
             if (eventHubClient == null)
                 throw new ArgumentNullException("eventHubClient");
-            if (outputTemplate == null) 
+            if (outputTemplate == null)
                 throw new ArgumentNullException("outputTemplate");
 
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
 
-            return AzureEventHub(loggerConfiguration, formatter, eventHubClient, restrictedToMinimumLevel);
+            return AzureEventHub(loggerConfiguration, formatter, "text/plain", false, eventHubClient, restrictedToMinimumLevel);
         }
 
         /// <summary>
@@ -68,6 +68,8 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="formatter">Formatter used to convert log events to text.</param>
+        /// <param name="contentType">Content type that the <paramref name="formatter"/> produces.</param>
+        /// <param name="shouldIncludeProperties">Should the properties be included in the event data. You probably do not want this when using a JSON formatted that includes properties already.</param>
         /// <param name="eventHubClient">The Event Hub to use to insert the log entries to.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
@@ -75,6 +77,8 @@ namespace Serilog
         public static LoggerConfiguration AzureEventHub(
             this LoggerAuditSinkConfiguration loggerConfiguration,
             ITextFormatter formatter,
+            string contentType,
+            bool shouldIncludeProperties,
             EventHubProducerClient eventHubClient,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
         {
@@ -83,7 +87,7 @@ namespace Serilog
             if (eventHubClient == null)
                 throw new ArgumentNullException("eventHubClient");
 
-            var sink = new AzureEventHubSink(eventHubClient, formatter);
+            var sink = new AzureEventHubSink(eventHubClient, formatter, contentType, shouldIncludeProperties);
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
 
@@ -125,6 +129,8 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="formatter">Formatter used to convert log events to text.</param>
+        /// <param name="contentType">Content type that the <paramref name="formatter"/> produces.</param>
+        /// <param name="shouldIncludeProperties">Should the properties be included in the event data. You probably do not want this when using a JSON formatted that includes properties already.</param>
         /// <param name="connectionString">The Event Hub connection string.</param>
         /// <param name="eventHubName">The Event Hub name.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
@@ -133,6 +139,8 @@ namespace Serilog
         public static LoggerConfiguration AzureEventHub(
             this LoggerAuditSinkConfiguration loggerConfiguration,
             ITextFormatter formatter,
+            string contentType,
+            bool shouldIncludeProperties,
             string connectionString,
             string eventHubName,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum
@@ -146,7 +154,7 @@ namespace Serilog
                 throw new ArgumentNullException("eventHubName");
 
             var client = new EventHubProducerClient(connectionString, eventHubName);
-            return AzureEventHub(loggerConfiguration, formatter, client, restrictedToMinimumLevel);
+            return AzureEventHub(loggerConfiguration, formatter, contentType, shouldIncludeProperties, client, restrictedToMinimumLevel);
         }
     }
 }

--- a/src/Serilog.Sinks.AzureEventHub/LoggerConfigurationAzureEventHubExtensions.cs
+++ b/src/Serilog.Sinks.AzureEventHub/LoggerConfigurationAzureEventHubExtensions.cs
@@ -78,7 +78,7 @@ namespace Serilog
 
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
 
-            return AzureEventHub(loggerConfiguration, formatter, eventHubClient, restrictedToMinimumLevel, writeInBatches, period, batchPostingLimit);
+            return AzureEventHub(loggerConfiguration, formatter, "text/plain", false, eventHubClient, restrictedToMinimumLevel, writeInBatches, period, batchPostingLimit);
         }
 
         /// <summary>
@@ -86,6 +86,8 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="formatter">Formatter used to convert log events to text.</param>
+        /// <param name="contentType">Content type that the <paramref name="formatter"/> produces.</param>
+        /// <param name="shouldIncludeProperties">Should the properties be included in the event data. You probably do not want this when using a JSON formatted that includes properties already.</param>
         /// <param name="eventHubClient">The Event Hub to use to insert the log entries to.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="writeInBatches">Use a periodic batching sink, as opposed to a synchronous one-at-a-time sink; this alters the partition
@@ -97,6 +99,8 @@ namespace Serilog
         public static LoggerConfiguration AzureEventHub(
             this LoggerSinkConfiguration loggerConfiguration,
             ITextFormatter formatter,
+            string contentType,
+            bool shouldIncludeProperties,
             EventHubProducerClient eventHubClient,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             bool writeInBatches = false,
@@ -120,7 +124,9 @@ namespace Serilog
             {
                 var eventHubSink = new AzureEventHubBatchingSink(
                     eventHubClient,
-                    formatter);
+                    formatter,
+                    contentType,
+                    shouldIncludeProperties);
                 var batchingOptions = new PeriodicBatchingSinkOptions
                 {
                     BatchSizeLimit = batchSizeLimit,
@@ -133,7 +139,7 @@ namespace Serilog
             }
             else
             {
-                sink = new AzureEventHubSink(eventHubClient, formatter);
+                sink = new AzureEventHubSink(eventHubClient, formatter, contentType, shouldIncludeProperties);
             }
 
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
@@ -184,6 +190,8 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="formatter">Formatter used to convert log events to text.</param>
+        /// <param name="contentType">Content type that the <paramref name="formatter"/> produces.</param>
+        /// <param name="shouldIncludeProperties">Should the properties be included in the event data. You probably do not want this when using a JSON formatted that includes properties already.</param>
         /// <param name="connectionString">The Event Hub connection string.</param>
         /// <param name="eventHubName">The Event Hub name.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
@@ -196,6 +204,8 @@ namespace Serilog
         public static LoggerConfiguration AzureEventHub(
             this LoggerSinkConfiguration loggerConfiguration,
             ITextFormatter formatter,
+            string contentType,
+            bool shouldIncludeProperties,
             string connectionString,
             string eventHubName,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
@@ -213,7 +223,7 @@ namespace Serilog
 
             var client = new EventHubProducerClient(connectionString, eventHubName);
 
-            return AzureEventHub(loggerConfiguration, formatter, client, restrictedToMinimumLevel, writeInBatches, period, batchPostingLimit);
+            return AzureEventHub(loggerConfiguration, formatter, contentType, shouldIncludeProperties, client, restrictedToMinimumLevel, writeInBatches, period, batchPostingLimit);
         }
     }
 }

--- a/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
+++ b/src/Serilog.Sinks.AzureEventHub/Serilog.Sinks.AzureEventHub.csproj
@@ -21,8 +21,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.*"/> -->
-    <PackageReference Include="Serilog" Version="2.5.0"/>
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1"/>
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.4.1"/>
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.10.0" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubBatchingSink.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubBatchingSink.cs
@@ -85,7 +85,7 @@ namespace Serilog.Sinks.AzureEventHub
                     eventHubData.Properties.Add(nameof(logEvent.Exception), logEvent.Exception);
                 }
 
-                eventHubData.Properties.Add(nameof(logEvent.Properties), logEvent.Properties);
+                eventHubData.AddFlattenedProperties(logEvent);
 
                 batchedEvents.Add(eventHubData);
             }

--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubBatchingSink.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubBatchingSink.cs
@@ -32,18 +32,26 @@ namespace Serilog.Sinks.AzureEventHub
     {
         private readonly EventHubProducerClient _eventHubClient;
         private readonly ITextFormatter _formatter;
+        private readonly string _contentType;
+        private readonly bool _shouldIncludeProperties;
 
         /// <summary>
         /// Construct a sink that saves log events to the specified EventHubClient.
         /// </summary>
         /// <param name="eventHubClient">The EventHubClient to use in this sink.</param>
         /// <param name="formatter">Provides formatting for outputting log data</param>
+        /// <param name="contentType">Content type that the <paramref name="formatter"/> produces.</param>
+        /// <param name="shouldIncludeProperties">Should the properties be included in the event data.</param>
         public AzureEventHubBatchingSink(
             EventHubProducerClient eventHubClient,
-            ITextFormatter formatter)
+            ITextFormatter formatter,
+            string contentType,
+            bool shouldIncludeProperties)
         {
             _eventHubClient = eventHubClient;
             _formatter = formatter;
+            _contentType = contentType;
+            _shouldIncludeProperties = shouldIncludeProperties;
         }
 
         /// <inheritdoc />
@@ -64,7 +72,11 @@ namespace Serilog.Sinks.AzureEventHub
                     body = Encoding.UTF8.GetBytes(render.ToString());
                 }
 
-                var eventHubData = new EventData(body);
+                var eventHubData = EventHubsModelFactory.EventData(new BinaryData(body));
+                if (!string.IsNullOrWhiteSpace(_contentType))
+                {
+                    eventHubData.ContentType = _contentType;
+                }
 
                 eventHubData.Properties.Add("Timestamp", logEvent.Timestamp);
                 eventHubData.Properties.Add("Type", "SerilogEvent");
@@ -85,7 +97,10 @@ namespace Serilog.Sinks.AzureEventHub
                     eventHubData.Properties.Add(nameof(logEvent.Exception), logEvent.Exception);
                 }
 
-                eventHubData.AddFlattenedProperties(logEvent);
+                if (_shouldIncludeProperties)
+                {
+                    eventHubData.AddFlattenedProperties(logEvent);
+                }
 
                 batchedEvents.Add(eventHubData);
             }

--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubBatchingSink.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubBatchingSink.cs
@@ -63,13 +63,33 @@ namespace Serilog.Sinks.AzureEventHub
                     _formatter.Format(logEvent, render);
                     body = Encoding.UTF8.GetBytes(render.ToString());
                 }
+
                 var eventHubData = new EventData(body);
-                
+
+                eventHubData.Properties.Add("Timestamp", logEvent.Timestamp);
                 eventHubData.Properties.Add("Type", "SerilogEvent");
                 eventHubData.Properties.Add("Level", logEvent.Level.ToString());
 
+                if (logEvent.TraceId != null)
+                {
+                    eventHubData.Properties.Add(nameof(logEvent.TraceId), logEvent.TraceId?.ToString());
+                }
+
+                if (logEvent.SpanId != null)
+                {
+                    eventHubData.Properties.Add(nameof(logEvent.SpanId), logEvent.SpanId?.ToString());
+                }
+
+                if (logEvent.Exception != null)
+                {
+                    eventHubData.Properties.Add(nameof(logEvent.Exception), logEvent.Exception);
+                }
+
+                eventHubData.Properties.Add(nameof(logEvent.Properties), logEvent.Properties);
+
                 batchedEvents.Add(eventHubData);
             }
+
             return _eventHubClient.SendAsync(batchedEvents, new SendEventOptions() { PartitionKey = batchPartitionKey });
         }
 

--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubSink.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubSink.cs
@@ -78,7 +78,7 @@ namespace Serilog.Sinks.AzureEventHub
                 eventHubData.Properties.Add(nameof(logEvent.Exception), logEvent.Exception);
             }
 
-            eventHubData.Properties.Add(nameof(logEvent.Properties), logEvent.Properties);
+            eventHubData.AddFlattenedProperties(logEvent);
 
             //Unfortunately no support for async in Serilog yet
             //https://github.com/serilog/serilog/issues/134

--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubSink.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubSink.cs
@@ -57,9 +57,28 @@ namespace Serilog.Sinks.AzureEventHub
                 _formatter.Format(logEvent, render);
                 body = Encoding.UTF8.GetBytes(render.ToString());
             }
+
             var eventHubData = new EventData(body);
+            eventHubData.Properties.Add("Timestamp", logEvent.Timestamp);
             eventHubData.Properties.Add("Type", "SerilogEvent");
             eventHubData.Properties.Add("Level", logEvent.Level.ToString());
+
+            if (logEvent.TraceId != null)
+            {
+                eventHubData.Properties.Add(nameof(logEvent.TraceId), logEvent.TraceId?.ToString());
+            }
+
+            if (logEvent.SpanId != null)
+            {
+                eventHubData.Properties.Add(nameof(logEvent.SpanId), logEvent.SpanId?.ToString());
+            }
+
+            if (logEvent.Exception != null)
+            {
+                eventHubData.Properties.Add(nameof(logEvent.Exception), logEvent.Exception);
+            }
+
+            eventHubData.Properties.Add(nameof(logEvent.Properties), logEvent.Properties);
 
             //Unfortunately no support for async in Serilog yet
             //https://github.com/serilog/serilog/issues/134

--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubSink.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/AzureEventHubSink.cs
@@ -29,20 +29,28 @@ namespace Serilog.Sinks.AzureEventHub
     /// </summary>
     public class AzureEventHubSink : ILogEventSink
     {
-        readonly EventHubProducerClient _eventHubClient;
-        readonly ITextFormatter _formatter;
+        private readonly EventHubProducerClient _eventHubClient;
+        private readonly ITextFormatter _formatter;
+        private readonly string _contentType;
+        private readonly bool _shouldIncludeProperties;
 
         /// <summary>
         /// Construct a sink that saves log events to the specified EventHubClient.
         /// </summary>
         /// <param name="eventHubClient">The EventHubClient to use in this sink.</param>
         /// <param name="formatter">Provides formatting for outputting log data</param>
+        /// <param name="contentType">Content type that the <paramref name="formatter"/> produces.</param>
+        /// <param name="shouldIncludeProperties">Should the properties be included in the event data.</param>
         public AzureEventHubSink(
             EventHubProducerClient eventHubClient,
-            ITextFormatter formatter)
+            ITextFormatter formatter,
+            string contentType,
+            bool shouldIncludeProperties)
         {
             _eventHubClient = eventHubClient;
             _formatter = formatter;
+            _contentType = contentType;
+            _shouldIncludeProperties = shouldIncludeProperties;
         }
 
         /// <summary>
@@ -58,7 +66,12 @@ namespace Serilog.Sinks.AzureEventHub
                 body = Encoding.UTF8.GetBytes(render.ToString());
             }
 
-            var eventHubData = new EventData(body);
+            var eventHubData = EventHubsModelFactory.EventData(new BinaryData(body));
+            if (!string.IsNullOrWhiteSpace(_contentType))
+            {
+                eventHubData.ContentType = _contentType;
+            }
+
             eventHubData.Properties.Add("Timestamp", logEvent.Timestamp);
             eventHubData.Properties.Add("Type", "SerilogEvent");
             eventHubData.Properties.Add("Level", logEvent.Level.ToString());
@@ -78,7 +91,10 @@ namespace Serilog.Sinks.AzureEventHub
                 eventHubData.Properties.Add(nameof(logEvent.Exception), logEvent.Exception);
             }
 
-            eventHubData.AddFlattenedProperties(logEvent);
+            if (_shouldIncludeProperties)
+            {
+                eventHubData.AddFlattenedProperties(logEvent);
+            }
 
             //Unfortunately no support for async in Serilog yet
             //https://github.com/serilog/serilog/issues/134

--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/PropertyDictionaryExtensions.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/PropertyDictionaryExtensions.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// SPDX-FileCopyrightText: 2017 Justin Detmar
+// SPDX-License-Identifier: MIT
+// Source: https://github.com/JDetmar/NLog.Extensions.AzureStorage/blob/9acec1c06306adada497671b7ef05a0a814fff30/src/NLog.Extensions.AzureEventHub/EventHubTarget.cs#L452
+
+using System;
 using System.Globalization;
 using Azure.Messaging.EventHubs;
 using Serilog.Events;

--- a/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/PropertyDictionaryExtensions.cs
+++ b/src/Serilog.Sinks.AzureEventHub/Sinks/AzureEventHub/PropertyDictionaryExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Globalization;
+using Azure.Messaging.EventHubs;
+using Serilog.Events;
+
+namespace Serilog.Sinks.AzureEventHub
+{
+    internal static class PropertyDictionaryExtensions
+    {
+        public static void AddFlattenedProperties(this EventData eventData, LogEvent logEvent)
+        {
+            var properties = eventData.Properties;
+
+            foreach (var property in logEvent.Properties)
+            {
+                var propertyName = property.Key;
+                var value = FlattenPropertyValue(propertyName, property.Value);
+                if (value != null)
+                {
+                    properties[propertyName] = value;
+                }
+            }
+        }
+
+        private static object FlattenPropertyValue(string name, object value)
+        {
+            try
+            {
+                if (value is IConvertible convertible)
+                {
+                    return value;
+                }
+                else if (value is IFormattable formattable)
+                {
+                    return formattable.ToString(null, CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    return value?.ToString();
+                }
+            }
+            catch (Exception ex)
+            {
+                Debugging.SelfLog.WriteLine("Failed converting property {0} value '{1}' to EventData: {2}", name, value?.GetType(), ex);
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add `shouldIncludeProperties` option to include context properties in event data
- Implement `IBatchedLogEventSink` instead of inheriting from the deprecated `PeriodicBatchingSink`
- Update references NuGet packages